### PR TITLE
Prevent content overflow of `<main>`

### DIFF
--- a/shared/styles.css
+++ b/shared/styles.css
@@ -7,6 +7,7 @@ body {
 }
 
 main {
+  width: 100%;
   max-width: 1200px;
 }
 


### PR DESCRIPTION
Set the `width` CSS property of the `<main>` tag to 100%. This combines with the existing `max-width` of 1200px, meaning that on screens narrower than 1200px, the main will not overflow horizontally.