### PR TITLE
Add viewport meta tag for better mobile view

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=360px, initial-scale=1">
 
     <!-- General Meta Tags -->
     <title>{{ page_title_long }}</title>

--- a/alphabetizer/styles.css
+++ b/alphabetizer/styles.css
@@ -1,8 +1,3 @@
-textarea#log-text, pre {
-  min-height: 100px;
-  min-width: 600px;
-}
-
 label.mdc-text-field--textarea, pre {
   margin: auto;
   clear: both;

--- a/case-converter/styles.css
+++ b/case-converter/styles.css
@@ -1,8 +1,3 @@
-textarea#log-text, pre {
-  min-height: 100px;
-  min-width: 600px;
-}
-
 label.mdc-text-field--textarea, pre {
   margin: auto;
   clear: both;

--- a/generic-formatter/styles.css
+++ b/generic-formatter/styles.css
@@ -1,8 +1,3 @@
-textarea#log-text, pre {
-  min-height: 100px;
-  min-width: 600px;
-}
-
 label.mdc-text-field--textarea, pre {
   margin: auto;
   clear: both;

--- a/shared/styles.css
+++ b/shared/styles.css
@@ -35,5 +35,18 @@ footer a:not(:hover) {
 }
 
 .description {
+  width: 100%;
   max-width: 800px;
+}
+
+textarea#log-text, pre {
+  min-height: 100px;
+  width: 100%;
+}
+
+@media (max-width: 30em){
+  h1.mdc-typography.mdc-typography--headline1 {
+    font-size: 2.5em;
+	width: 100%;
+  }
 }

--- a/stack-extractor/styles.css
+++ b/stack-extractor/styles.css
@@ -1,8 +1,3 @@
-textarea#log-text, pre {
-  min-height: 100px;
-  min-width: 600px;
-}
-
 label.mdc-text-field--textarea, pre {
   margin: auto;
   clear: both;

--- a/trimmer/styles.css
+++ b/trimmer/styles.css
@@ -1,8 +1,3 @@
-textarea#log-text, pre {
-  min-height: 100px;
-  min-width: 600px;
-}
-
 label.mdc-text-field--textarea, pre {
   margin: auto;
   clear: both;

--- a/url-cleaner/styles.css
+++ b/url-cleaner/styles.css
@@ -1,8 +1,3 @@
-textarea#log-text, pre {
-  min-height: 100px;
-  min-width: 600px;
-}
-
 label.mdc-text-field--textarea, pre {
   margin: auto;
   clear: both;


### PR DESCRIPTION
The viewport is requested to be a minimum of 480px wide, and to maintain an initial scale of 1. For devices which are narrower than 480 display pixels, this results in a horizontal scroll bar. For devices which are wider, the width is treated a minimum, and the full device width will be used.

Additional information can be found in https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag